### PR TITLE
Fix empty player name

### DIFF
--- a/engine.php
+++ b/engine.php
@@ -599,6 +599,15 @@ class Controller_Singleton
         return $status_table;
     }
 
+    function validate_player_name($string)
+    {
+        if ( $string == "" )
+        {
+            return "Unnamed Player";
+        }
+
+        return $string;
+    }
 
     function players_html($address, $css_prefix="dptable_")
     {
@@ -613,7 +622,7 @@ class Controller_Singleton
             foreach ( $status["clients.players"] as $player )
                 $players->data_row( array (
                     new HTML_TableCell(
-                        $address->protocol->string->to_html($player->name),
+                        $address->protocol->string->to_html($this->validate_player_name($player->name)),
                         false,
                         array('class'=>"{$css_prefix}player_name")
                     ),

--- a/string.php
+++ b/string.php
@@ -356,7 +356,7 @@ class StringParser
     function parse($string)
     {
         if ( $string == "" )
-            return [];
+            return new MyString();
 
         $this->output = new MyString();
         $this->subject = $string;


### PR DESCRIPTION
1. Fix this crash when a player name is empty:

```
Fatal error:  Uncaught Error: Call to a member function to_html() on array in …/wp-content/plugins/xonpress/string.php:388
Stack trace:
#0 …/wp-content/plugins/xonpress/engine.php(616): StringParser->to_html('')
#1 …/wp-content/plugins/xonpress/engine.php(666): Controller_Singleton->players_html(Object(Engine_Address))
#2 …/wp-content/plugins/xonpress/xp_shortcodes.php(101): Controller_Singleton->server_list_html(Array)
#3 …/wp-includes/shortcodes.php(345): xonpress_server_list(Array, '', 'xon_server_list')
#4 [internal function]: do_shortcode_tag(Array)
#5 …/wp-includes/shortcodes.php(223): preg_replace_callback('/\\[(\\[?)(xon_se...', 'do_shortcode_ta...', '<div id=&quot;pl-340...')
#6 …/wp-includes/class-wp-hook.php(298): do_shortcode('<div id=&quot;pl-340...')
#7 …/wp-includes/plugin.php(203): WP_Hook->apply_filters('<div id=&quot;pl-340...', Ar in …/wp-content/plugins/xonpress/string.php on line 388
```

This happened because there was a code testing if the string was empty and returned an empty array instead of an empty string in that case (if not empty, the string is processed, looking for color codes or things like that).

2. Display `Unnamed Player` if player name is empty.